### PR TITLE
Fix author name from ``Yuvan'' to ``Yuval''

### DIFF
--- a/_posts/2018-04-09-dagan18a.md
+++ b/_posts/2018-04-09-dagan18a.md
@@ -1,15 +1,15 @@
 ---
 title: A Better Resource Allocation Algorithm with Semi-Bandit Feedback
-abstract: "We study a sequential resource allocation problem between a fixed\r number
-  of arms. On each iteration the algorithm distributes a\r resource among the arms
-  in order to maximize the expected success\r rate. Allocating more of the resource
-  to a given arm increases the\r probability that it succeeds, yet with a cut-off.
-  We follow\r \\cite{LCS} and assume that the probability increases\r linearly until
-  it equals one, after which allocating more of the\r resource is wasteful. These
-  cut-off values are fixed and unknown to\r the learner. We present an algorithm for
-  this problem and\r prove a regret upper bound of $O(\\log n)$ improving over the
-  best\r known bound of $O(\\log^2 n)$. Lower bounds we prove show that our\r upper
-  bound is tight. Simulations demonstrate the superiority of our\r algorithm."
+abstract: "We study a sequential resource allocation problem between a fixed number
+  of arms. On each iteration the algorithm distributes a resource among the arms
+  in order to maximize the expected success rate. Allocating more of the resource
+  to a given arm increases the probability that it succeeds, yet with a cut-off.
+  We follow \cite{LCS} and assume that the probability increases linearly until
+  it equals one, after which allocating more of the resource is wasteful. These
+  cut-off values are fixed and unknown to the learner. We present an algorithm for
+  this problem and prove a regret upper bound of $O(\log n)$ improving over the
+  best known bound of $O(\log^2 n)$. Lower bounds we prove show that our upper
+  bound is tight. Simulations demonstrate the superiority of our algorithm."
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: dagan18a

--- a/_posts/2018-04-09-dagan18a.md
+++ b/_posts/2018-04-09-dagan18a.md
@@ -21,7 +21,7 @@ page: 268-320
 order: 268
 cycles: false
 author:
-- given: Yuvan
+- given: Yuval
   family: Dagan
 - given: Crammer
   family: Koby


### PR DESCRIPTION
Fixing the name of the author in the paper "A better resource allocation algorithm with semi bandit feedback" (ALT 2018, proceedings)